### PR TITLE
i7: enable deployment tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,3 +94,40 @@ The Slack analytics integration service provides users access to curated informa
 	Mentioned by these users: @andreag, @claudiaw, @gregory, @jennym, @sabines, @yvonnet
 	Mentioned in these channels: #general, #geospatial, #offline-first
 	```	
+
+### Privacy Notice
+
+Sample web applications that include this package may be configured to track deployments to [IBM Bluemix](https://www.bluemix.net/) and other Cloud Foundry platforms. The following information is sent to a [Deployment Tracker](https://github.com/IBM-Bluemix/cf-deployment-tracker-service) service on each deployment:
+
+* Node.js package version
+* Node.js repository URL
+* Application Name (`application_name`)
+* Space ID (`space_id`)
+* Application Version (`application_version`)
+* Application URIs (`application_uris`)
+* Labels of bound services
+* Number of instances for each bound service and associated plan information
+
+This data is collected from the `package.json` file in the sample application and the `VCAP_APPLICATION` and `VCAP_SERVICES` environment variables in IBM Bluemix and other Cloud Foundry platforms. This data is used by IBM to track metrics around deployments of sample applications to IBM Bluemix to measure the usefulness of our examples, so that we can continuously improve the content we offer to you. Only deployments of sample applications that include code to ping the Deployment Tracker service will be tracked.
+
+### Disabling Deployment Tracking	
+
+Deployment tracking can be disabled by removing the following line from `app.js`:
+
+```
+require("cf-deployment-tracker-client").track();
+```
+
+Once that line is removed, you may also uninstall the `cf-deployment-tracker-client` npm package.
+
+### License 
+
+Copyright [2016] [IBM Cloud Data Services]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/app.js
+++ b/app.js
@@ -187,3 +187,5 @@ const StatsCollector = require('./lib/stats_collector.js');
 	    console.log('Server starting on ' + appEnv.url);
 	 });
 
+	// send sample application deployment tracking request to https://github.com/IBM-Bluemix/cf-deployment-tracker-service
+	require('cf-deployment-tracker-client').track();

--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.ibm.com/analytics-advocacy/slack-analytics-about-service.git"
+    "url": "https://github.com/ibm-cds-labs/slack-analytics-about-service.git"
   },
   "keywords": [
-    "slack"
+    "slack",
+    "ibm graph"
   ],
   "author": "ptitzler@us.ibm.com",
   "license": "Apache-2.0",
@@ -19,6 +20,7 @@
   "dependencies": {
     "async": "^2.0.0-rc.4",
     "body-parser": "^1.15.1",
+    "cf-deployment-tracker-client": "^0.1.1",
     "cfenv": "^1.0.3",
     "debug": "^2.2.0",
     "express": "^4.13.4",
@@ -27,7 +29,7 @@
     "request": "^2.72.0",
     "util": "^0.10.3"
   },
-   "devDependencies": {
+  "devDependencies": {
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",
     "grunt-contrib-jshint": "0.12.0",


### PR DESCRIPTION
Used https://github.com/IBM-Bluemix/cf-deployment-tracker-client-node to track and updated readme.
